### PR TITLE
Add dockerfile and docker usage instructions on README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM kalilinux/kali-rolling
+RUN apt-get update && apt-get -yu dist-upgrade -y
+WORKDIR /rapidscan
+RUN apt-get install -y \
+  python2.7 \
+  wget \
+  dmitry \
+  dnsrecon \
+  wapiti \
+  nmap \
+  sslyze \
+  dnsenum \
+  wafw00f \
+  golismero \
+  dirb \
+  host \
+  lbd \
+  xsser \
+  dnsmap \
+  dnswalk \
+  fierce \
+  davtest \
+  whatweb \
+  nikto \
+  uniscan \
+  whois \
+  theharvester
+
+RUN wget -O rapidscan.py https://raw.githubusercontent.com/skavngr/rapidscan/master/rapidscan.py && chmod +x rapidscan.py
+RUN ln -s /rapidscan/rapidscan.py /usr/local/bin/rapidscan
+WORKDIR /reports
+ENTRYPOINT ["rapidscan"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,5 @@ RUN apt-get install -y \
 
 RUN wget -O rapidscan.py https://raw.githubusercontent.com/skavngr/rapidscan/master/rapidscan.py && chmod +x rapidscan.py
 RUN ln -s /rapidscan/rapidscan.py /usr/local/bin/rapidscan
-RUN ln -s /usr/bin/python2.7 /usr/bin/python
 WORKDIR /reports
 ENTRYPOINT ["rapidscan"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,6 @@ RUN apt-get install -y \
 
 RUN wget -O rapidscan.py https://raw.githubusercontent.com/skavngr/rapidscan/master/rapidscan.py && chmod +x rapidscan.py
 RUN ln -s /rapidscan/rapidscan.py /usr/local/bin/rapidscan
+RUN ln -s /usr/bin/python2.7 /usr/bin/python
 WORKDIR /reports
 ENTRYPOINT ["rapidscan"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@
 **Download the script and give executable permissions**
 - `wget -O rapidscan.py https://raw.githubusercontent.com/skavngr/rapidscan/master/rapidscan.py && chmod +x rapidscan.py`
 
+### With docker
+To run a scan for `example.com` the command below has to be run. After completion reports can be found in the current path under `reports`. 
+```
+docker run -t --rm -v $(pwd)/reports:/reports kanolato/rapidscan example.com
+```
+> It is also possible to see rapidscan options running: docker run -t --rm kanolato/rapidscan
+
 ## Help
 ![rapidscan help](https://github.com/skavngr/rapidscan/blob/master/splashscreen_rapidscan_help.PNG)
 


### PR DESCRIPTION
Thank you so much for this tool! It's been super useful. 
I have added some small improvements, a Dockerfile and instructions to use it.
The Docker image is currently residing on my account `kanolato/rapidscan`, but I think we should put it under yours :)